### PR TITLE
[iOS] Unicode replaced AM/PM separator from a SPACE (U+0020) to a NARROW NO-BREAK SPACE (U+202F)

### DIFF
--- a/Sources/GXUITest/GXUITestingAPI.swift
+++ b/Sources/GXUITest/GXUITestingAPI.swift
@@ -837,12 +837,16 @@ public class SdtUITestSD {
 		if received == expected {
 			return true
 		}
-		else {
+		else if !received.hasPrefix(" AM") || !received.hasPrefix(" PM"){
+			var expectedSpace = received.replacingOccurrences(of: "AM", with: " AM")
+			expectedSpace = received.replacingOccurrences(of: "PM", with: " PM")
+			return received == expectedSpace
+		}
+		else if received.hasPrefix("\n"){
 			let expectedNoNewlines = expected.replacingOccurrences(of: "\n", with: " ")
 			return received == expectedNoNewlines
 		}
 	}
-}
 
 // MARK: - Internal variables and functions
 


### PR DESCRIPTION
Unicode replaced the A.M./P.M. separator from a SPACE (U+0020) to a NARROW NO-BREAK SPACE (U+202F). 
The change affects iOS 17+ versions
[https://unicode-org.atlassian.net/browse/CLDR-14032](url)