### PR TITLE
Recreate image (PNG data) in correct orientation

### DIFF
--- a/Sources/GXUITest/HelperExtensions.swift
+++ b/Sources/GXUITest/HelperExtensions.swift
@@ -75,6 +75,34 @@ internal extension CGImage {
 	}
 }
 
+private extension UIImage.Orientation {
+	var isLandscape: Bool {
+		switch self {
+		case .left, .right, .leftMirrored, .rightMirrored:
+			return true
+			
+		default:
+			return false
+		}
+	}
+}
+
+internal extension UIImage {
+	func rotatedPngData() -> Data? {
+		guard self.imageOrientation != .up else { return self.pngData() }
+		
+		guard let cgImage else { return nil }
+		
+		var size = self.imageOrientation.isLandscape ? .init(width: self.size.height, height: self.size.width) : self.size
+		size = size.scaled(by: 1 / self.scale)
+		
+		let renderer = UIGraphicsImageRenderer(size: size, format: self.imageRendererFormat)
+		return renderer.pngData { ctx in
+			ctx.cgContext.draw(cgImage, in: .init(origin: .zero, size: size))
+		}
+	}
+}
+
 internal extension UIEdgeInsets {
 	func scaled(by scale: CGFloat) -> UIEdgeInsets {
 		UIEdgeInsets.init(top: self.top * scale, left: self.left * scale, bottom: self.bottom * scale, right: self.right * scale)

--- a/Sources/GXUITest/VisualTestingProvider.swift
+++ b/Sources/GXUITest/VisualTestingProvider.swift
@@ -124,13 +124,9 @@ internal class VisualTestingProvider {
 	}
 	
 	private func uploadImage(image: UIImage) throws -> String? {
-		guard let requestURL = imageUploadURL else {
-			throw VisualTestingError.invalidURL
-		}
+		guard let requestURL = imageUploadURL else { throw VisualTestingError.invalidURL }
 		
-		guard let pngData = image.pngData() else {
-			return nil
-		}
+		guard let pngData = image.rotatedPngData() else { return nil }
 		
 		return awaitPost(toURL: requestURL, data: pngData, mimeType: "image/png", resultKey: "object_id")
 	}

--- a/Tests/GXUITestUnitTests/UIImage+Tests.swift
+++ b/Tests/GXUITestUnitTests/UIImage+Tests.swift
@@ -1,0 +1,51 @@
+//
+//  UIImage+Tests.swift
+//
+//
+//  Created by José Echagüe on 10/10/23.
+//
+
+import XCTest
+
+@testable import GXUITest
+
+public class UIImage_Tests : XCTestCase {
+	public func test_rotatedPngData_downOrientation() throws {
+		let image = try XCTUnwrap(UIImage(named: "expectedImage_3", in: Bundle.module, compatibleWith: nil),
+								  "Unable to load image for test from xcassets")
+		let rotatedImage = UIImage(cgImage: image.cgImage!, scale: image.scale, orientation: .down)
+		
+		let pngData = try XCTUnwrap(rotatedImage.rotatedPngData())
+		let imageFromData = try XCTUnwrap(UIImage(data: pngData))
+		
+		XCTAssertEqual(rotatedImage.size, imageFromData.size)
+		XCTAssertFalse(try rotatedImage.perceptuallyCompare(toFiduciary: imageFromData, pixelPrecision: 1.0, perceptualPrecision: 1.0))
+	}
+	
+	public func test_rotatedPngData_upOrientation() throws {
+		let image = try XCTUnwrap(UIImage(named: "expectedImage_3", in: Bundle.module, compatibleWith: nil),
+								  "Unable to load image for test from xcassets")
+		
+		let rotatedPngData = try XCTUnwrap(image.rotatedPngData())
+		let pngData = try XCTUnwrap(image.pngData())
+		
+		XCTAssertEqual(rotatedPngData, pngData)
+	}
+	
+	public func test_rotatedPngData_Idempotency() throws {
+		let image = try XCTUnwrap(UIImage(named: "expectedImage_3", in: Bundle.module, compatibleWith: nil),
+								  "Unable to load image for test from xcassets")
+		let rotatedImage = UIImage(cgImage: image.cgImage!, scale: image.scale, orientation: .down)
+		
+		let singleRotationPngData = try XCTUnwrap(rotatedImage.rotatedPngData())
+		let singleRotationImage = try XCTUnwrap(UIImage(data: singleRotationPngData))
+		
+		let doubleRotationImage = UIImage(cgImage: singleRotationImage.cgImage!, scale: image.scale, orientation: .down)
+		let doubleRotationPngData = try XCTUnwrap(doubleRotationImage.rotatedPngData())
+		
+		let resultingImage = try XCTUnwrap(UIImage(data: doubleRotationPngData))
+		
+		XCTAssertEqual(rotatedImage.size, resultingImage.size)
+		XCTAssertTrue(try rotatedImage.perceptuallyCompare(toFiduciary: resultingImage, pixelPrecision: 1.0, perceptualPrecision: 1.0))
+	}
+}

--- a/Tests/GXUITestUnitTests/VisualTestingProvider+Tests.swift
+++ b/Tests/GXUITestUnitTests/VisualTestingProvider+Tests.swift
@@ -81,7 +81,7 @@ class VisualTestingProvider_Tests_ProviderWithURL : XCTestCase {
 		
 		stub(condition: isAbsoluteURLString("http://example.com/image.png")) { request in
 			guard let randomImage = TestHelpers.generateRandomImage(),
-				  let pngImageData = randomImage.pngData() else {
+				  let pngImageData = randomImage.rotatedPngData() else {
 				return TestHelpers.fail(with: "Unable to generate image for response")
 			}
 			

--- a/Tests/IntegrationTests/UITestingSampleApp/UITestingSampleApp.xcodeproj/project.pbxproj
+++ b/Tests/IntegrationTests/UITestingSampleApp/UITestingSampleApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2B1B32FF2AD5CD32006BD2C2 /* UITestingSampleAppUITestsGeneratedScreenshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B1B32FE2AD5CD32006BD2C2 /* UITestingSampleAppUITestsGeneratedScreenshotTests.swift */; };
 		2B1C15852A8A8A2600015A71 /* UITestingSampleAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B1C15842A8A8A2600015A71 /* UITestingSampleAppApp.swift */; };
 		2B1C15872A8A8A2600015A71 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B1C15862A8A8A2600015A71 /* ContentView.swift */; };
 		2B1C15892A8A8A2900015A71 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2B1C15882A8A8A2900015A71 /* Assets.xcassets */; };
@@ -27,6 +28,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		2B1B32FE2AD5CD32006BD2C2 /* UITestingSampleAppUITestsGeneratedScreenshotTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITestingSampleAppUITestsGeneratedScreenshotTests.swift; sourceTree = "<group>"; };
 		2B1C15812A8A8A2600015A71 /* UITestingSampleApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = UITestingSampleApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2B1C15842A8A8A2600015A71 /* UITestingSampleAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestingSampleAppApp.swift; sourceTree = "<group>"; };
 		2B1C15862A8A8A2600015A71 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -102,6 +104,7 @@
 		2B1C159F2A8A8A2900015A71 /* UITestingSampleAppUITests */ = {
 			isa = PBXGroup;
 			children = (
+				2B1B32FE2AD5CD32006BD2C2 /* UITestingSampleAppUITestsGeneratedScreenshotTests.swift */,
 				2B1C15A22A8A8A2900015A71 /* UITestingSampleAppUITestsScreenshotClippingTests.swift */,
 				2B4ACCF42AC11306003FA184 /* UITestingSampleApp.xctestplan */,
 				2BA961112ACDA45C001A1EF5 /* UITestingSampleAppUITestsGeneratedIntegrationTests.swift */,
@@ -229,6 +232,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2B1C15A32A8A8A2900015A71 /* UITestingSampleAppUITestsScreenshotClippingTests.swift in Sources */,
+				2B1B32FF2AD5CD32006BD2C2 /* UITestingSampleAppUITestsGeneratedScreenshotTests.swift in Sources */,
 				2BA961122ACDA45C001A1EF5 /* UITestingSampleAppUITestsGeneratedIntegrationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tests/IntegrationTests/UITestingSampleApp/UITestingSampleAppUITests/UITestingSampleAppUITestsGeneratedScreenshotTests.swift
+++ b/Tests/IntegrationTests/UITestingSampleApp/UITestingSampleAppUITests/UITestingSampleAppUITestsGeneratedScreenshotTests.swift
@@ -1,0 +1,31 @@
+//
+//  UITestingSampleAppUITestsGeneratedScreenshotTests.swift
+//
+//
+//  Created by José Echagüe on 10/10/23.
+//
+
+import XCTest
+
+@testable import GXUITest
+
+final class UITestingSampleAppUITestsGeneratedScreenshotTests: XCTestCase {
+	
+	override class var runsForEachTargetApplicationUIConfiguration: Bool { false }
+	
+	func testDeviceOrientation_ShouldBePreserved() throws {
+		let app = XCUIApplication()
+		app.launch()
+		
+		XCUIDevice.shared.orientation = .landscapeLeft
+		
+		let screenshot = GXUITestingHelpers.screenshotImage(from: XCUIScreen.main, clipToSafeArea: .none)
+		
+		let pngData = try XCTUnwrap(screenshot.rotatedPngData())
+		let reconstructedImage = try XCTUnwrap(UIImage(data: pngData))
+		
+		// Height and width are swapped because reconstructed image always has orientation = .up
+		XCTAssertEqual(screenshot.size.height, reconstructedImage.size.width, accuracy: 0.5)
+		XCTAssertEqual(screenshot.size.width, reconstructedImage.size.height, accuracy: 0.5)
+	}
+}


### PR DESCRIPTION
The PNG format doesn't store image orientation, so images need to be rendered in the `up` orientation so the PNG representation is in the correct orientation.