### PR TITLE
Add XcodeTools package as dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -45,15 +45,6 @@
       }
     },
     {
-      "identity" : "gxxcodetools",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jechague/GXXcodeTools.git",
-      "state" : {
-        "branch" : "main",
-        "revision" : "da21f4b9128af2b68664000ac6db5af8c63e1cfc"
-      }
-    },
-    {
       "identity" : "ohhttpstubs",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/AliSoftware/OHHTTPStubs.git",
@@ -87,6 +78,14 @@
       "state" : {
         "revision" : "0b77e67c484e532444ceeab60119b8536f8cd648",
         "version" : "0.3.0"
+      }
+    },
+    {
+      "identity" : "xcodetools",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/GeneXus-SwiftPackages/XcodeTools.git",
+      "state" : {
+        "revision" : "7d8c246ae52a189241823ac5bfc3abd7c567bd73"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,12 +1,20 @@
 {
   "pins" : [
     {
+      "identity" : "collectionconcurrencykit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/happn-app/CollectionConcurrencyKit.git",
+      "state" : {
+        "revision" : "b2b4dc4b363cf4301586f75d24b9ffe17111a286"
+      }
+    },
+    {
       "identity" : "gxdatalayer",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GeneXus-SwiftPackages/GXDataLayer.git",
       "state" : {
-        "revision" : "fa1bbb0f0d5c3a3d465125debdd2e86bf62d13c4",
-        "version" : "1.1.0"
+        "revision" : "16d6a3f0ead461eeaebec00d6d84cc73737d9c34",
+        "version" : "1.1.3"
       }
     },
     {
@@ -14,8 +22,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GeneXus-SwiftPackages/GXFoundation.git",
       "state" : {
-        "revision" : "bc2fe741da9bb14119a44ad79ecc9e59ba3d0a6b",
-        "version" : "1.1.0"
+        "revision" : "91a0e69622e973237a9366dedec77882ab40cec4",
+        "version" : "1.1.3"
       }
     },
     {
@@ -23,8 +31,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GeneXus-SwiftPackages/GXObjectsModel.git",
       "state" : {
-        "revision" : "7dceda23687951f97ef09604085d7e5bc1dd1f4d",
-        "version" : "1.1.0"
+        "revision" : "d7b4de3fd7de1b6c133db29f377d23433c7b40ae",
+        "version" : "1.1.3"
       }
     },
     {
@@ -32,8 +40,53 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GeneXus-SwiftPackages/GXStandardClasses.git",
       "state" : {
-        "revision" : "29ac2159e25ad6b45760c217d01601ae8522815a",
-        "version" : "1.1.0"
+        "revision" : "e16e6f7f8ace5d4d4ff55f209103f0b0fb28286d",
+        "version" : "1.1.3"
+      }
+    },
+    {
+      "identity" : "gxxcodetools",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jechague/GXXcodeTools.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "fd77a2953bf4506301ad303bb05e15a1c3c8e286"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "8f4d2753f0e4778c76d5f05ad16c74f707390531",
+        "version" : "1.2.3"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "836bc4557b74fe6d2660218d56e3ce96aff76574",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-tools-support-core",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-tools-support-core.git",
+      "state" : {
+        "revision" : "0b77e67c484e532444ceeab60119b8536f8cd648",
+        "version" : "0.3.0"
+      }
+    },
+    {
+      "identity" : "xcparse",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ChargePoint/xcparse.git",
+      "state" : {
+        "revision" : "5ec59315a5d752e560ab09080a4821244c279038",
+        "version" : "2.3.1"
       }
     },
     {
@@ -50,8 +103,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GeneXus-SwiftPackages/YAJL.git",
       "state" : {
-        "revision" : "65d223bac5586c86d2783026018ddaa99c6bf410",
-        "version" : "1.1.0"
+        "revision" : "042c32613b24f3278d45d802b773e109140c0193",
+        "version" : "1.1.3"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -50,7 +50,16 @@
       "location" : "https://github.com/jechague/GXXcodeTools.git",
       "state" : {
         "branch" : "main",
-        "revision" : "fd77a2953bf4506301ad303bb05e15a1c3c8e286"
+        "revision" : "da21f4b9128af2b68664000ac6db5af8c63e1cfc"
+      }
+    },
+    {
+      "identity" : "ohhttpstubs",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/AliSoftware/OHHTTPStubs.git",
+      "state" : {
+        "revision" : "12f19662426d0434d6c330c6974d53e2eb10ecd9",
+        "version" : "9.1.0"
       }
     },
     {
@@ -87,15 +96,6 @@
       "state" : {
         "revision" : "5ec59315a5d752e560ab09080a4821244c279038",
         "version" : "2.3.1"
-      }
-    },
-    {
-      "identity" : "ohhttpstubs",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/AliSoftware/OHHTTPStubs.git",
-      "state" : {
-        "revision" : "12f19662426d0434d6c330c6974d53e2eb10ecd9",
-        "version" : "9.1.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -11,12 +11,14 @@ let package = Package(
 	],
 	dependencies: [
 		.package(url: "https://github.com/GeneXus-SwiftPackages/GXStandardClasses.git", .upToNextMajor(from: "1.1.0-beta")),
-		.package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", from: "9.1.0")
+		.package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", from: "9.1.0"),
+        .package(url: "https://github.com/jechague/GXXcodeTools.git", branch: "main")
 	],
 	targets: [
 		.target(name: "GXUITest",
 				dependencies: [
 					.product(name: "GXStandardClasses", package: "GXStandardClasses"),
+					.product(name: "RunGXTests", package: "GXXcodeTools")
 				]
 		),
 

--- a/Package.swift
+++ b/Package.swift
@@ -3,11 +3,12 @@ import PackageDescription
 
 let package = Package(
 	name: "GXUITest",
-	platforms: [.iOS("12.0")],
+	platforms: [.iOS("12.0"), .macOS("13.0")],
 	products: [
 		.library(
 			name: "GXUITest",
-			targets: ["GXUITest"])
+			targets: ["GXUITest"]),
+		.plugin(name: "ExecuteTests", targets: ["ExecuteTests"])
 	],
 	dependencies: [
 		.package(url: "https://github.com/GeneXus-SwiftPackages/GXStandardClasses.git", .upToNextMajor(from: "1.1.0-beta")),
@@ -18,9 +19,17 @@ let package = Package(
 		.target(name: "GXUITest",
 				dependencies: [
 					.product(name: "GXStandardClasses", package: "GXStandardClasses"),
-					.product(name: "RunGXTests", package: "GXXcodeTools")
 				]
 		),
+		
+		// MARK: Plugin targets
+		
+		.plugin(name: "ExecuteTests",
+				capability: .command(intent: .custom(verb: "run-tests", description: "Run and extract results from GX Tests in project")),
+			   dependencies: [
+				.product(name: "RunTests", package: "GXXcodeTools"),
+				.product(name: "ExtractTestResults", package: "GXXcodeTools")
+			   ]),
 
 		.testTarget(name: "GXUITestUnitTests",
 				   dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
 	dependencies: [
 		.package(url: "https://github.com/GeneXus-SwiftPackages/GXStandardClasses.git", .upToNextMajor(from: "1.1.0-beta")),
 		.package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", from: "9.1.0"),
-        .package(url: "https://github.com/jechague/GXXcodeTools.git", branch: "main")
+        .package(url: "https://github.com/GeneXus-SwiftPackages/XcodeTools.git", branch: "7d8c246ae52a189241823ac5bfc3abd7c567bd73")
 	],
 	targets: [
 		.target(name: "GXUITest",
@@ -27,8 +27,8 @@ let package = Package(
 		.plugin(name: "ExecuteTests",
 				capability: .command(intent: .custom(verb: "run-tests", description: "Run and extract results from GX Tests in project")),
 			   dependencies: [
-				.product(name: "RunTests", package: "GXXcodeTools"),
-				.product(name: "ExtractTestResults", package: "GXXcodeTools")
+				.product(name: "RunTests", package: "XcodeTools"),
+				.product(name: "ExtractTestResults", package: "XcodeTools")
 			   ]),
 
 		.testTarget(name: "GXUITestUnitTests",

--- a/Plugins/ExecuteTests/RunTests.swift
+++ b/Plugins/ExecuteTests/RunTests.swift
@@ -1,0 +1,143 @@
+//
+//  RunTests.swift
+//
+//
+//  Created by José Echagüe on 8/11/23.
+//
+
+import Foundation
+import PackagePlugin
+
+private protocol ToolProvider {
+	func tool(named name: String) throws -> PackagePlugin.PluginContext.Tool
+}
+
+extension PluginContext: ToolProvider {  }
+
+@main
+struct RunTests {
+	private func runTestsTool(from toolProvider: ToolProvider) throws -> PackagePlugin.PluginContext.Tool {
+		try toolProvider.tool(named: "RunTests")
+	}
+	
+	private func extrctResultsTool(from toolProvider: ToolProvider) throws -> PackagePlugin.PluginContext.Tool {
+		try toolProvider.tool(named: "ExtractTestResults")
+	}
+	
+	/// Expected arguments:
+	///  - Required:
+	///  -- projectPath (non-relative)
+	///  -- schemeName
+	///  -- testDestination (must double-quoted in order to be parsed correctly by the swift package command)
+	///  - Optional:
+	///  -- --swift-packages-path
+	///  -- --xcode-override
+	///  -- Rest of arguments are the names of tests to execute
+	private func runAndExtractTests(using context: ToolProvider, arguments: [String], extractionPath: String) throws {
+		guard arguments.count >= 3 else { throw Error.invalidNumberOfArguments }
+		
+		var projectPath = arguments[0]
+		if !projectPath.hasSuffix(".xcodeproj") {
+			projectPath.append(".xcodeproj")
+		}
+		
+		let schemeName = arguments[1]
+		let testDestination = arguments[2]
+
+		var testExecutionArguments = [projectPath, schemeName, testDestination]
+		
+		if arguments.count >= 6 {
+			testExecutionArguments.append(contentsOf: arguments[5...])
+		}
+		
+		testExecutionArguments.append(contentsOf: ["--results-path", extractionPath])
+		
+		if arguments.count >= 4 {
+			testExecutionArguments.append(contentsOf: ["--swift-packages-path", arguments[3]])
+			
+			if arguments.count >= 5 {
+				testExecutionArguments.append(contentsOf: ["--xcode-override", arguments[4]])
+			}
+		}
+		
+		let runTestsTool = try self.runTestsTool(from: context)
+		let xcResultsPath = try self.runProcess(with: runTestsTool.path.string, arguments: testExecutionArguments)
+		
+#if DEBUG
+			print("Test results path: \(xcResultsPath)")
+#endif
+		
+		let extractResultsTool = try self.extrctResultsTool(from: context)
+		let extractTestsResults = try self.runProcess(with: extractResultsTool.path.string, arguments: [xcResultsPath, extractionPath ,"--extract-logs"])
+		
+		print(extractTestsResults)
+	}
+	
+	private func runProcess(with launchPath: String, arguments: [String]) throws -> String {
+#if DEBUG
+		print("Launching process with launch path: \(launchPath)")
+		print("Launch arguments: \(arguments)")
+#endif
+		var shellArguments = [launchPath]
+		shellArguments.append(contentsOf: arguments)
+		
+		let process = Process()
+		process.launchPath = launchPath
+		process.arguments = arguments
+		
+		let outputPipe = Pipe()
+		process.standardOutput = outputPipe
+		let errorPipe = Pipe()
+		process.standardError = errorPipe
+		
+		process.launch()
+		process.waitUntilExit()
+		
+		guard process.terminationStatus == 0 else {
+			let stdError = String(decoding: errorPipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+			
+			throw Error.runtimeError(stdError, process.terminationStatus)
+		}
+		
+		return String(decoding: outputPipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
+	}
+}
+
+
+extension RunTests: CommandPlugin {
+	func performCommand(context: PluginContext, arguments: [String]) async throws {
+		guard let extractionPath = arguments.last else { throw Error.invalidNumberOfArguments }
+		
+		try self.runAndExtractTests(using: context, arguments: Array(arguments[0..<(arguments.count-1)]), extractionPath: extractionPath)
+	}
+}
+
+
+#if canImport(XcodeProjectPlugin)
+import XcodeProjectPlugin
+
+extension XcodePluginContext: ToolProvider {  }
+
+extension RunTests: XcodeCommandPlugin {
+	func performCommand(context: XcodePluginContext, arguments: [String]) throws {
+		guard arguments.count >= 3 else { throw Error.invalidNumberOfArguments }
+		
+		let targetName = arguments[1]
+		let testDestination = arguments[2]
+		let buildProductDirPath = context.xcodeProject.directory.appending(["build"]).string
+		let testProductDirPath = context.xcodeProject.directory.appending(["test"]).string
+		
+		let pluginArguments = [context.xcodeProject.directory.appending([context.xcodeProject.displayName]).string,
+							   targetName,
+							   testDestination,
+							   buildProductDirPath]
+		
+		try self.runAndExtractTests(using: context, arguments: pluginArguments, extractionPath: testProductDirPath)
+	}
+}
+#endif // canImport(XcodeProjectPlugin)
+
+private enum Error: Swift.Error, LocalizedError {
+	case runtimeError(String, Int32)
+	case invalidNumberOfArguments
+}


### PR DESCRIPTION
The XcodeTools package contains the executables to build and run UI Tests.

This PR adds a Swift command-line plugin that uses the executables from XcodeTools. The plugin needs to be defined in this repository to avoid Xcode's security warnings. The plugin also extracts test results from the resulting XCResult bundle so they're later downloaded by GeneXus.