### PR TITLE
Depend on new major version of the iOS flexible client: 3.0  

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GeneXus-SwiftPackages/GXDataLayer.git",
       "state" : {
-        "revision" : "d43a3a10a9e25c3e860f5345d26cae09f028d181",
-        "version" : "2.0.0-beta.5"
+        "revision" : "5d82d02cf965b7558da09a13d2c7f2cff212b35f",
+        "version" : "3.0.0-beta.2"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GeneXus-SwiftPackages/GXFoundation.git",
       "state" : {
-        "revision" : "c6ba71bb17b697270c3de4c6592066d69ffc995f",
-        "version" : "2.0.0-beta.5"
+        "revision" : "9e714e4154c39d23a7d2cfa2a8124ebbcf078980",
+        "version" : "3.0.0-beta.2"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GeneXus-SwiftPackages/GXObjectsModel.git",
       "state" : {
-        "revision" : "062fc02dbb37a6fa80a5e1c4fb9d44f067829835",
-        "version" : "2.0.0-beta.5"
+        "revision" : "936da7b4688ef32213aacb44d87b84a305fcb896",
+        "version" : "3.0.0-beta.2"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GeneXus-SwiftPackages/GXStandardClasses.git",
       "state" : {
-        "revision" : "c1c12bd4889f57aca44f5f40206f707b343fff70",
-        "version" : "2.0.0-beta.5"
+        "revision" : "042605cdcd393e59d35b0e5693e0b9538b4b637e",
+        "version" : "3.0.0-beta.2"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GeneXus-SwiftPackages/YAJL.git",
       "state" : {
-        "revision" : "d60df3cc94140926881178445cc06dff06bb9d6e",
-        "version" : "2.0.0-beta.5"
+        "revision" : "aeaae2542bbba09477eb846a392b58355f90c225",
+        "version" : "3.0.0-beta.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,11 @@
 // swift-tools-version: 5.9
 import PackageDescription
 
-let GX_FC_LAST_VERSION = Version("2.0.0-beta")
+let GX_FC_LAST_VERSION = Version("3.0.0-beta")
 
 let package = Package(
 	name: "GXUITest",
-	platforms: [.iOS("12.0")],
+	platforms: [.iOS("13.0")],
 	products: [
 		.library(
 			name: "GXUITest",

--- a/Tests/GXUITestUnitTests/VisualTestingProvider+Tests.swift
+++ b/Tests/GXUITestUnitTests/VisualTestingProvider+Tests.swift
@@ -276,7 +276,8 @@ class TestHelpers {
 	}
 }
 
-extension HTTPStubsResponse : Error {  }
+extension HTTPStubsResponse: @unchecked Sendable { }
+extension HTTPStubsResponse : @retroactive Error { }
 
 private extension HTTPStubsResponse {
 	static var genericClientErrorResponse : HTTPStubsResponse {


### PR DESCRIPTION
Bump minimum supported version of iOS to 13.0 (same as new version of flexible client).

Silence warnings related to Swift 6 concurrency mode.