### PR TITLE
Fix issue 104123

### DIFF
--- a/Sources/GXUITest/GXUITestingAPI.swift
+++ b/Sources/GXUITest/GXUITestingAPI.swift
@@ -862,6 +862,7 @@ fileprivate let _allElementTypes: Array<XCUIElement.ElementType> = [.textField,
 																	.checkBox,
 																	.switch,
 																	.segmentedControl,
+								    									.scrollView,
 																	.other]
 
 fileprivate let _tapableElementTypes: Array<XCUIElement.ElementType> = [.button,
@@ -874,7 +875,7 @@ fileprivate let _tapableElementTypes: Array<XCUIElement.ElementType> = [.button,
 																		.checkBox,
 																		.switch,
 																		.segmentedControl,
-                                                                        .scrollView,
+																		.scrollView,
 																		.other]
 
 fileprivate let _textInputElementTypes: Array<XCUIElement.ElementType> = [.textField,

--- a/Sources/GXUITest/GXUITestingAPI.swift
+++ b/Sources/GXUITest/GXUITestingAPI.swift
@@ -874,6 +874,7 @@ fileprivate let _tapableElementTypes: Array<XCUIElement.ElementType> = [.button,
 																		.checkBox,
 																		.switch,
 																		.segmentedControl,
+                                                                        .scrollView,
 																		.other]
 
 fileprivate let _textInputElementTypes: Array<XCUIElement.ElementType> = [.textField,


### PR DESCRIPTION
Added .scrollView to the list of _tapableElementTypes and _allElementTypes to ensure that elements within a ScrollView are detected correctly.  Prior to this change, controls inside Grid1.item(x) were not found because ScrollView was not considered an interacting element, blocking the search for elements such as Noticiaimagen.