### PR TITLE
Fix VerifyText on hidden control

### DIFF
--- a/Sources/GXUITest/GXUITestingAPI.swift
+++ b/Sources/GXUITest/GXUITestingAPI.swift
@@ -229,8 +229,8 @@ public class SdtUITestSD : VisualTestingServerProvider {
 	public func verifytext(_ text: String, _ expected: Bool = true, _ context: String? = nil) {
 		runActivity(forAction: "VerifyText", target: text, inContext: context) {
 			let timeout: TimeInterval = expected ? DEFAULT_ELEMENT_EXISTANCE_TIMEOUT : DEFAULT_ELEMENT_NON_EXISTANCE_TIMEOUT
-			let found: Bool = _findElement(.visibleText(text), context: context, includingContextElement: true, timeout: timeout) != nil
-			XCTAssert(found == expected, "Text '\(text)' was \(expected ? "" : "not ")expected but did \(found ? "" : "not ")find it")
+			let foundAndVisible: Bool = _findElement(.visibleText(text), context: context, includingContextElement: true, timeout: timeout)?.isHittable ?? false
+			XCTAssert(foundAndVisible == expected, "Text '\(text)' was \(expected ? "" : "not ")expected but did \(foundAndVisible ? "" : "not ")find it")
 		}
 	}
 	


### PR DESCRIPTION
This PR fixes the VerifyText method.
It was only considering element existence but not if it was visible or not.

Issue:204659