### PR TITLE
Fix override throw type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           cancel-in-progress: true
 
         env:
-          XCODE_VERSION_PATH: /Applications/Xcode_26.2.app
+          XCODE_VERSION_PATH: /Applications/Xcode_26.5.app
           TEST_DESTINATION: platform=iOS Simulator,name=iPhone 17,OS=latest
 
         steps:

--- a/.github/workflows/integrationTests.yml
+++ b/.github/workflows/integrationTests.yml
@@ -11,7 +11,7 @@ jobs:
     integration-tests:
         strategy:
             matrix:
-              xcode-version: ["26.2", "26.0.1"]
+              xcode-version: ["26.5", "26.0.1"]
               device: [iPhone 17, iPhone 17 Pro]
               exclude:
                 - xcode-version: "26.0.1"

--- a/Sources/GXUITest/UIImage+ImageComparison.swift
+++ b/Sources/GXUITest/UIImage+ImageComparison.swift
@@ -136,7 +136,7 @@ private final class ThresholdImageProcessorKernel: CIImageProcessorKernel {
 	static let inputThresholdKey = "thresholdValue"
 	static let device = MTLCreateSystemDefaultDevice()
 	
-	override class func process(with inputs: [CIImageProcessorInput]?, arguments: [String: Any]?, output: CIImageProcessorOutput) throws(GXUITestError) {
+	override class func process(with inputs: [CIImageProcessorInput]?, arguments: [String: Any]?, output: CIImageProcessorOutput) throws {
 		guard
 			let device = device,
 			let commandBuffer = output.metalCommandBuffer,


### PR DESCRIPTION
This PR fixes `ThresholdImageProcessorKernel` method override `process(with:arguments:output:) throws` by removing error type from throw.
Xcode 26.0 compiles OK, but latest versions of Xcode 26 catches this error.