### PR TITLE
Liquid Glass fixes

### DIFF
--- a/Sources/GXUITest/HelperExtensions.swift
+++ b/Sources/GXUITest/HelperExtensions.swift
@@ -25,8 +25,19 @@ internal extension XCUIElement {
 	}
 	
 	private func dismissKeyboard() {
-		/// As documented in example: https://developer.apple.com/documentation/xctest/grouping-tests-into-substeps-with-activities#Organize-Long-Test-Methods-into-Substeps
-		XCUIApplication().children(matching: .window).firstMatch.tap()
+		/// Based on documented example: https://developer.apple.com/documentation/xctest/grouping-tests-into-substeps-with-activities#Organize-Long-Test-Methods-into-Substeps
+		let centerVector = CGVector(dx: 0.5, dy: 0.5)
+		let window = XCUIApplication().children(matching: .window).firstMatch
+		let windowCenterCoordinate = window.coordinate(withNormalizedOffset: centerVector)
+		if #available(iOS 26, tvOS 26, watchOS 26, visionOS 26, *) {
+			/// On iOS 26 with Liquid Glass design, if the target coordinate is within the element frame, it does not dismiss the keyboard. Tap on the bottom rigth corner as a WA.
+			guard !frame.contains(windowCenterCoordinate.screenPoint) else {
+				let cornerVector = CGVector(dx: 1, dy: 1)
+				coordinate(withNormalizedOffset: cornerVector).tap()
+				return
+			}
+		}
+		windowCenterCoordinate.tap()
 	}
 	
 	private func tapContextMenuItem(_ menuItem: String, required: Bool = true) {
@@ -46,6 +57,9 @@ internal extension XCUIElement {
 					exists = menuItemElement.waitForExistence(timeout: waitForExistenceTimeout)
 				}
 				guard exists || required else {
+					if menuItems.firstMatch.exists {
+						tap() /// Dismiss existing context menu if it does not include the menuItemElement
+					}
 					return
 				}
 			}


### PR DESCRIPTION
This PR fixes issues when Liquid Glass design is enabled in iOS 26 related to fill command.
- Dismiss keyboard was not working when window center point is contained in focused element frame, as a WA tap on a corner of the element instead.
- Dismiss menu if element does not exist and it was not required (i.e. "Select All" on empty text field).

**Note** that it's now required "Connect Hardware Keyboard" simulator setting to be disabled for the fill command to succeed (probably due to a bug in Apple's [typeText(_:)](https://developer.apple.com/documentation/xcuiautomation/xcuielement/typetext(_:)) implementation).
This will be handled by assigning this setting (disable "Connect Hardware Keyboard") before tests execution.